### PR TITLE
Better manage dependency execution with `tools.go`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/go-modules-by-example/tools
 
 go 1.12
 
-require golang.org/x/tools v0.0.0-20190511041617-99f201b6807e // indirect
+require golang.org/x/tools v0.0.0-20190511041617-99f201b6807e

--- a/painkiller.go
+++ b/painkiller.go
@@ -2,7 +2,7 @@ package main
 
 import "fmt"
 
-//go:generate stringer -type=Pill
+//go:generate go run golang.org/x/tools/cmd/stringer -type=Pill
 
 type Pill int
 


### PR DESCRIPTION
As highlighted in https://www.jvt.me/posts/2022/06/15/go-tools-dependency-management/ this makes it much simpler to manage, and doesn't require explicit installing of tools before executing `go generate`